### PR TITLE
fix: 질문/리뷰 작성 시 textEditor 반대로 입력되는 오류 수정

### DIFF
--- a/client/src/Components/AskForm/TextEditor.jsx
+++ b/client/src/Components/AskForm/TextEditor.jsx
@@ -25,7 +25,8 @@ const CustomToolbar = () => (
   </div>
 );
 
-const TextEditor = ({ handleText }) => {
+const TextEditor = ({ handleText, questionContent }) => {
+  console.log(questionContent);
   const modules = {
     toolbar: {
       container: '#toolbar',
@@ -54,12 +55,12 @@ const TextEditor = ({ handleText }) => {
     <div className="text-editor" style={{ height: '350px', width: '100%' }}>
       <CustomToolbar />
       <ReactQuill
-        // value={questionContent}
+        value={questionContent}
+        defaultValue={questionContent}
         style={{ height: '300px', fontsize: '15px' }}
         modules={modules}
         formats={formats}
         theme="snow"
-        // value={text}
         onChange={(content, delta, source, editor) =>
           handleText(editor.getText())
         }

--- a/client/src/Components/AskForm/TextEditor.jsx
+++ b/client/src/Components/AskForm/TextEditor.jsx
@@ -26,7 +26,6 @@ const CustomToolbar = () => (
 );
 
 const TextEditor = ({ handleText, questionContent }) => {
-  console.log(questionContent);
   const modules = {
     toolbar: {
       container: '#toolbar',


### PR DESCRIPTION
* 질문/리뷰 작성 및 질문 수정 페이지 내에서 textEditor 사용 시 입력 커서가 맨 앞으로 이동하여 사용자 입력값이 반대로 입력되는 오류 수정하 자잘한 PR 작성합니다