### PR TITLE
[FE] feat : 관리자 로그인 시에만 관리자 메뉴 활성화

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,6 +16,7 @@ const ReviewDetail = lazy(() => import('./Pages/ReviewDetail/ReviewDetail'));
 const QuestionDetail = lazy(() =>
   import('./Pages/QuestionDetail/QuestionDetail')
 );
+const Admin = lazy(() => import('./Pages/Admin/Admin'));
 
 import { createGlobalStyle } from 'styled-components';
 import { reset } from 'styled-reset';
@@ -42,6 +43,7 @@ function App() {
         <Route path="/home/question/:postId" element={<QuestionDetail />} />
         <Route path="/home/review/:postId/" element={<ReviewDetail />} />
         <Route path="/home/question/edit/:postId" element={<EditQuestion />} />
+        <Route path="/admin" element={<Admin />} />
       </Routes>
       <Footer />
     </>

--- a/client/src/Components/Header/Header.jsx
+++ b/client/src/Components/Header/Header.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import Cookies from 'universal-cookie';
 import Nav from '../Nav/Nav';
 import { Popover, Avatar } from 'antd';
@@ -14,16 +14,17 @@ import {
   SNotification,
   SMyInfo,
   SLogout,
+  SAdminNav,
 } from '../../Style/HeaderStyle';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { loginState, loggedUserInfo } from '../../atoms/atoms';
+import { loginState, loggedUserInfo, adminState } from '../../atoms/atoms';
 
 function Header() {
   const [isLogged, setIsLogged] = useRecoilState(loginState); // 로그인 여부
   const userInfo = useRecoilValue(loggedUserInfo);
+  const isAdmin = useRecoilValue(adminState);
 
   const cookies = new Cookies();
-  const navigate = useNavigate();
 
   const [isOpenNav, setIsOpenNav] = useState(false);
 
@@ -31,14 +32,13 @@ function Header() {
     setIsOpenNav(!isOpenNav);
   };
 
-  const handleClickLogout = (e) => {
-    e.preventDefault();
+  const handleClickLogout = () => {
     setIsLogged(!isLogged);
     localStorage.removeItem('accessToken');
     localStorage.removeItem('recoil-persist');
     localStorage.removeItem('loggedUserInfo');
     cookies.remove('refreshToken');
-    navigate('/');
+    location.reload();
   };
 
   return (
@@ -56,6 +56,13 @@ function Header() {
               </Link>
             </SLogo>
             <SNav onClick={handleClickNav}>커뮤니티</SNav>
+            {isAdmin ? (
+              <SAdminNav>
+                <Link to="/admin">Admin</Link>
+              </SAdminNav>
+            ) : (
+              <></>
+            )}
           </div>
           <div>
             {!isLogged ? (

--- a/client/src/Pages/Login/Login.jsx
+++ b/client/src/Pages/Login/Login.jsx
@@ -23,12 +23,12 @@ import {
   SModalSignupBtn,
 } from '../../Style/LoginStyle';
 import axios from 'axios';
-import { useSetRecoilState } from 'recoil';
-import { loginState, loggedUserInfo } from '../../atoms/atoms';
+import { useSetRecoilState, useRecoilState } from 'recoil';
+import { loginState, loggedUserInfo, adminState } from '../../atoms/atoms';
 
 const Login = () => {
   const setIsLogged = useSetRecoilState(loginState);
-  const setUserInfo = useSetRecoilState(loggedUserInfo);
+  const [userInfo, setUserInfo] = useRecoilState(loggedUserInfo);
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -46,6 +46,16 @@ const Login = () => {
 
   const cookies = new Cookies();
   const navigate = useNavigate();
+
+  const [isAdmin, setIsAdmin] = useRecoilState(adminState);
+
+  useEffect(() => {
+    if (userInfo?.email === 'admin@mail.com') {
+      setIsAdmin(!isAdmin);
+    } else {
+      setIsAdmin(isAdmin);
+    }
+  }, [userInfo]);
 
   // enter key를 이용한 submit 구현
   const handdlerEnter = (event) => {

--- a/client/src/Style/HeaderStyle.js
+++ b/client/src/Style/HeaderStyle.js
@@ -56,6 +56,21 @@ export const SNav = styled.nav`
   }
 `;
 
+export const SAdminNav = styled(SNav)`
+  padding: 16px 0 !important;
+  a {
+    text-decoration: none;
+    font-family: 'TheJamsil';
+    font-weight: 600;
+    font-size: 16px;
+    color: var(--blue-600);
+    :hover {
+      color: var(--blue-400);
+    }
+  }
+  cursor: pointer;
+`;
+
 export const SLogin = styled.div`
   padding: 16px 16px;
   button {

--- a/client/src/atoms/atoms.js
+++ b/client/src/atoms/atoms.js
@@ -16,3 +16,10 @@ export const loggedUserInfo = atom({
   default: null,
   effects_UNSTABLE: [persistAtom],
 });
+
+// 관리자 로그인 상태
+export const adminState = atom({
+  key: 'adminState',
+  default: false,
+  effects_UNSTABLE: [persistAtom],
+});


### PR DESCRIPTION
### feat : 관리자 로그인 시에만 관리자 메뉴 활성화

- [관리자 계정으로 로그인, 관리자 메뉴 활성화 상태]
![스크린샷, 2023-03-22 18-03-20](https://user-images.githubusercontent.com/115627384/226854015-5f92b105-34e9-4131-aeb0-af0c1e1cffc5.png)

- [이동한 관리자 페이지]
![스크린샷, 2023-03-22 18-03-36](https://user-images.githubusercontent.com/115627384/226854054-756152af-341e-45e3-a961-bac2ca572c3d.png)

- [관리자 로그아웃 후, 관리자 메뉴 비활성화 상태]
![스크린샷, 2023-03-22 18-03-56](https://user-images.githubusercontent.com/115627384/226854097-6624590f-2896-4668-be48-92759fb9872c.png)

** 관리자 계정
아이디 : admin@mail.com
비밀번호 : qwer1234!